### PR TITLE
Fix release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,10 +23,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: 3
-      - run: gem install asciidoctor
+      - run: sudo gem install asciidoctor
+        if: "!contains(matrix.target, 'windows')"
       - run: sudo apt-get install musl-tools
         if: contains(matrix.target, 'linux-musl')
       - shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,10 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: 3
-      - run: gem install asciidoctor
+      - run: sudo gem install asciidoctor
       - run: asciidoctor -b manpage -a reproducible mdcat.1.adoc
 
   cargo-deny:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ To publish a new release run `scripts/release` from the project directory.
 
 ## [Unreleased]
 
+### Fixed
+- Fix release workflow to restore release artifacts (see [GH-218]).
+
+[GH-218]: https://github.com/swsnr/mdcat/pull/218
+
 ## [0.30.2] – 2022-12-01
 
 ### Changed

--- a/scripts/package
+++ b/scripts/package
@@ -17,7 +17,10 @@ package_windows() {
     local archive_file
     archive_file="${ARCHIVE_NAME}.zip"
     mv LICENSE LICENSE.txt
-    7z a "${archive_file}" "./target/${TARGET}/release/mdcat.exe" ./README.md ./CHANGELOG.md ./LICENSE.txt "${OUTDIR}/completions" ./mdcat.1.adoc
+    7z a "${archive_file}" \
+        "./target/${TARGET}/release/mdcat.exe" \
+        ./README.md ./CHANGELOG.md ./LICENSE.txt ./mdcat.1.adoc \
+        "${OUTDIR}/completions"
     if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
         echo "file=${archive_file}" >>"${GITHUB_OUTPUT}"
         echo "name=${ARCHIVE_NAME}.zip" >>"${GITHUB_OUTPUT}"
@@ -32,9 +35,11 @@ package_unix() {
     pkg_dir=$(mktemp -d)
 
     mkdir "${pkg_dir}/${ARCHIVE_NAME}"
-    cp README.md CHANGELOG.md LICENSE "target/${TARGET}/release/mdcat" "${pkg_dir}/${ARCHIVE_NAME}"
-    cp -r "${OUTDIR}/completions" "${pkg_dir}/${ARCHIVE_NAME}"
-    cp "${OUTDIR}/mdcat.1" "${pkg_dir}/${ARCHIVE_NAME}"
+    cp -r \
+        README.md CHANGELOG.md LICENSE \
+        "target/${TARGET}/release/mdcat" \
+        "${OUTDIR}/mdcat.1" "${OUTDIR}/completions" \
+        "${pkg_dir}/${ARCHIVE_NAME}"
     tar -czf "${PWD}/${archive_file}" -C "${pkg_dir}" "${ARCHIVE_NAME}"
     echo "file=${archive_file}" >>"${GITHUB_OUTPUT}"
     echo "name=${ARCHIVE_NAME}.tar.gz" >>"${GITHUB_OUTPUT}"


### PR DESCRIPTION
Get rid of `ruby/setup-ruby` because it messes up `$PATH`, and include manpage in all release artifacts.