### PR TITLE
[don't merge] ratatui widget

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "ahash"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77c3a9648d43b9cd48db467b3f87fdd6e146bcc88ab0180006cef2179fe11d01"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -40,6 +52,12 @@ checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
 dependencies = [
  "alloc-no-stdlib",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
 name = "anstream"
@@ -94,6 +112,12 @@ name = "anyhow"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
+
+[[package]]
+name = "arc-swap"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
 
 [[package]]
 name = "arrayref"
@@ -191,6 +215,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "brotli"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -247,6 +280,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 
 [[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
 name = "cc"
 version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -293,6 +332,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete_fig"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e571d70e22ec91d34e1c5317c8308035a2280d925167646bf094fc5de1737c"
+dependencies = [
+ "clap",
+ "clap_complete",
+]
+
+[[package]]
+name = "clap_complete_nushell"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "948bf70d7e1f179635d3ef819ce8baa2d3074d0d57816ac37387cd6f9eed0c31"
+dependencies = [
+ "clap",
+ "clap_complete",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -301,7 +360,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -385,10 +444,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 
 [[package]]
+name = "crossterm"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
+dependencies = [
+ "bitflags 2.4.1",
+ "crossterm_winapi",
+ "libc",
+ "mio",
+ "parking_lot",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
 
 [[package]]
 name = "data-url"
@@ -403,6 +497,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -562,12 +687,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -577,10 +718,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
 
 [[package]]
+name = "futures-executor"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-io"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
 
 [[package]]
 name = "futures-sink"
@@ -600,13 +763,26 @@ version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
  "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -685,6 +861,10 @@ name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
 
 [[package]]
 name = "heck"
@@ -801,6 +981,16 @@ dependencies = [
 
 [[package]]
 name = "idna"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "idna"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
@@ -808,6 +998,12 @@ dependencies = [
  "unicode-bidi",
  "unicode-normalization",
 ]
+
+[[package]]
+name = "if_chain"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb56e1aa765b4b4f3aadfab769793b7087bb03a4ea4920644a6d238e2df5b9ed"
 
 [[package]]
 name = "image"
@@ -844,10 +1040,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8"
+
+[[package]]
 name = "ipnet"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
+
+[[package]]
+name = "itertools"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25db6b064527c5d482d0423354fcd07a89a2dfe07b67892e62411946db7f07b0"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -871,6 +1082,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a1d36f1235bc969acba30b7f5990b864423a6068a10f7c90ae8f0112e3a59d1"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "kamadak-exif"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef4fc70d0ab7e5b6bafa30216a6b48705ea964cdfc29c050f2412295eba58077"
+dependencies = [
+ "mutate_once",
 ]
 
 [[package]]
@@ -899,6 +1119,17 @@ name = "libc"
 version = "0.2.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
+
+[[package]]
+name = "libredox"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
+dependencies = [
+ "bitflags 2.4.1",
+ "libc",
+ "redox_syscall",
+]
 
 [[package]]
 name = "line-wrap"
@@ -932,12 +1163,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
+name = "lru"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2994eeba8ed550fd9b47a0b38f0242bc3344e496483c6180b69139cc2fa5d1d7"
+dependencies = [
+ "hashbrown",
+]
+
+[[package]]
 name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
  "regex-automata 0.1.10",
+]
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
 ]
 
 [[package]]
@@ -1022,9 +1272,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "mutate_once"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16cf681a23b4d0a43fc35024c176437f9dcd818db34e0f42ab456a0ee5ad497b"
 
 [[package]]
 name = "native-tls"
@@ -1070,6 +1327,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
  "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
+dependencies = [
  "libc",
 ]
 
@@ -1133,7 +1399,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1153,6 +1419,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "os_info"
@@ -1193,6 +1465,12 @@ dependencies = [
  "smallvec",
  "windows-targets 0.48.5",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "percent-encoding"
@@ -1258,6 +1536,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1282,7 +1584,9 @@ name = "pulldown-cmark-mdcat"
 version = "2.1.1"
 dependencies = [
  "anstyle",
+ "anyhow",
  "base64",
+ "crossterm",
  "gethostname",
  "glob",
  "image",
@@ -1290,6 +1594,7 @@ dependencies = [
  "mime",
  "mime_guess",
  "pulldown-cmark",
+ "ratatui",
  "resvg",
  "rustix",
  "similar-asserts",
@@ -1299,7 +1604,10 @@ dependencies = [
  "textwrap",
  "thiserror",
  "tracing",
+ "unicode-segmentation",
+ "unicode-width",
  "url",
+ "yazi-adaptor",
 ]
 
 [[package]]
@@ -1327,6 +1635,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "ratatui"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5659e52e4ba6e07b2dad9f1158f578ef84a73762625ddb51536019f34d180eb"
+dependencies = [
+ "bitflags 2.4.1",
+ "cassowary",
+ "crossterm",
+ "indoc",
+ "itertools",
+ "lru",
+ "paste",
+ "stability",
+ "strum",
+ "unicode-segmentation",
+ "unicode-width",
 ]
 
 [[package]]
@@ -1362,6 +1689,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4"
+dependencies = [
+ "getrandom",
+ "libredox",
+ "thiserror",
 ]
 
 [[package]]
@@ -1574,6 +1912,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
+
+[[package]]
 name = "rustybuzz"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1675,7 +2019,7 @@ checksum = "46fe8f8603d81ba86327b23a2e9cdf49e1255fb94a4c5f297f6ee0547178ea2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1724,6 +2068,36 @@ name = "shell-words"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "simd-adler32"
@@ -1810,6 +2184,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "stability"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebd1b177894da2a2d9120208c3386066af06a488255caabc5de8ddca22dbc3ce"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1831,6 +2215,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
+name = "strum"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.48",
+]
+
+[[package]]
 name = "svgtypes"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1838,6 +2244,17 @@ checksum = "6e44e288cd960318917cbd540340968b90becc8bc81f171345d706e7a89d9d70"
 dependencies = [
  "kurbo",
  "siphasher",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -1963,7 +2380,7 @@ checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1995,6 +2412,8 @@ checksum = "f657ba42c3f86e7680e53c8cd3af8abbe56b5491790b46e22e19c0d57463583e"
 dependencies = [
  "deranged",
  "itoa",
+ "libc",
+ "num_threads",
  "powerfmt",
  "serde",
  "time-core",
@@ -2068,9 +2487,23 @@ dependencies = [
  "libc",
  "mio",
  "num_cpus",
+ "parking_lot",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2113,6 +2546,7 @@ version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1a195ec8c9da26928f773888e0742ca3ca1040c6cd859c919c9f59c1954ab35"
 dependencies = [
+ "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -2138,6 +2572,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -2165,7 +2600,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2204,6 +2639,12 @@ name = "ttf-parser"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17f77d76d837a7830fe1d4f12b7b4ba4192c1888001c7164257e4bc6d21d96b4"
+
+[[package]]
+name = "typenum"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "unicase"
@@ -2296,7 +2737,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
 dependencies = [
  "form_urlencoded",
- "idna",
+ "idna 0.5.0",
  "percent-encoding",
 ]
 
@@ -2377,10 +2818,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "validator"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b92f40481c04ff1f4f61f304d61793c7b56ff76ac1469f1beb199b1445b253bd"
+dependencies = [
+ "idna 0.4.0",
+ "lazy_static",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "url",
+ "validator_derive",
+]
+
+[[package]]
+name = "validator_derive"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc44ca3088bb3ba384d9aecf40c6a23a676ce23e09bdaca2073d99c207f864af"
+dependencies = [
+ "if_chain",
+ "lazy_static",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 1.0.109",
+ "validator_types",
+]
+
+[[package]]
+name = "validator_types"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "111abfe30072511849c5910134e8baf8dc05de4c0e5903d681cbd5c9c4d611e3"
+dependencies = [
+ "proc-macro2",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "vergen"
+version = "8.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cf9c2670809c4840d4648fc7daa396551d7d88966f9ba93821b81a5c0c2d3f5"
+dependencies = [
+ "anyhow",
+ "rustversion",
+ "time",
+]
 
 [[package]]
 name = "version_check"
@@ -2434,7 +2928,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.48",
  "wasm-bindgen-shared",
 ]
 
@@ -2468,7 +2962,7 @@ checksum = "bae1abb6806dc1ad9e560ed242107c0f6c84335f1749dd4e8ddb012ebd5e25a7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.48",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2659,6 +3153,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
+name = "winnow"
+version = "0.5.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7cf47b659b318dccbd69cc4797a39ae128f533dce7902a1096044d1967b9c16"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "winreg"
 version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2679,6 +3182,89 @@ name = "xmlwriter"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
+
+[[package]]
+name = "yazi-adaptor"
+version = "0.2.0"
+source = "git+https://github.com/lengyijun/yazi?branch=pub_more#77a0ff6806a3b52e1ad27adb979abbd16c36294a"
+dependencies = [
+ "anyhow",
+ "arc-swap",
+ "base64",
+ "color_quant",
+ "image",
+ "imagesize",
+ "kamadak-exif",
+ "ratatui",
+ "tokio",
+ "tracing",
+ "yazi-config",
+ "yazi-shared",
+]
+
+[[package]]
+name = "yazi-config"
+version = "0.2.0"
+source = "git+https://github.com/lengyijun/yazi?branch=pub_more#77a0ff6806a3b52e1ad27adb979abbd16c36294a"
+dependencies = [
+ "anyhow",
+ "arc-swap",
+ "clap",
+ "clap_complete",
+ "clap_complete_fig",
+ "clap_complete_nushell",
+ "crossterm",
+ "dirs",
+ "futures",
+ "glob",
+ "indexmap",
+ "md-5",
+ "ratatui",
+ "serde",
+ "shell-words",
+ "toml",
+ "validator",
+ "vergen",
+ "yazi-shared",
+]
+
+[[package]]
+name = "yazi-shared"
+version = "0.2.0"
+source = "git+https://github.com/lengyijun/yazi?branch=pub_more#77a0ff6806a3b52e1ad27adb979abbd16c36294a"
+dependencies = [
+ "anyhow",
+ "bitflags 2.4.1",
+ "crossterm",
+ "futures",
+ "libc",
+ "parking_lot",
+ "percent-encoding",
+ "ratatui",
+ "regex",
+ "serde",
+ "tokio",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
 
 [[package]]
 name = "zune-inflate"

--- a/pulldown-cmark-mdcat/Cargo.toml
+++ b/pulldown-cmark-mdcat/Cargo.toml
@@ -26,17 +26,23 @@ anstyle = { version = "1.0.0", default-features = false }
 mime = { version = "0.3.17", default-features = false }
 mime_guess = { version = "2.0.4", default-features = false }
 pulldown-cmark = { version = "0.9.2", default-features = false, features = ['simd'] }
-syntect = { version = "5.0.0", default-features = false, features = ["parsing"] }
+syntect = { version = "5.0.0", default-features = false, features = ["parsing",  "default-syntaxes"] }
 textwrap = { version = "0.16.0", default-features = false, features = ["unicode-linebreak", "unicode-width"] }
 thiserror = { version = "1.0.40", default-features = false }
 tracing = { version = "0.1.37", default-features = false, features = ["attributes"] }
 url = "2.3.1"
+yazi-adaptor = {git = "https://github.com/lengyijun/yazi", branch = "pub_more" }
 
 # Optional for svg support
 resvg = { version = "0.37.0", optional = true, default-features = false, features = ["text", "system-fonts", "memmap-fonts"] }
 # Optional for image processing support; we deliberately build with default
 # features to include all possible image formats
 image = { version = "0.24.6", optional = true }
+ratatui = "0.25.0"
+crossterm = "0.27.0"
+anyhow = "1.0.79"
+unicode-segmentation = "1.10.1"
+unicode-width = "0.1.11"
 
 [dev-dependencies]
 glob = "0.3.1"

--- a/pulldown-cmark-mdcat/examples/fast.rs
+++ b/pulldown-cmark-mdcat/examples/fast.rs
@@ -1,0 +1,79 @@
+use crossterm::{
+    event::{self, Event, KeyCode},
+    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+    ExecutableCommand,
+};
+use pulldown_cmark_mdcat::bufferline::BufferLine;
+use pulldown_cmark_mdcat::markdown_widget::FasterMarkdownWidget;
+use pulldown_cmark_mdcat::markdown_widget::{Offset, PathOrStr};
+use ratatui::prelude::*;
+use std::{
+    cell::OnceCell,
+    io::{self, stdout},
+    path::PathBuf,
+};
+
+fn main() -> io::Result<()> {
+    enable_raw_mode()?;
+    stdout().execute(EnterAlternateScreen)?;
+    let mut terminal = Terminal::new(CrosstermBackend::new(stdout()))?;
+
+    let mut offset = Offset { x: 0, y: 0 };
+    let cell: OnceCell<Vec<_>> = OnceCell::new();
+
+    'outer: loop {
+        terminal.draw(|frame| {
+            let area = frame.size();
+            let v = cell.get_or_init(|| {
+                vec![PathOrStr::from_md_path(
+                    PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap())
+                        .parent()
+                        .unwrap()
+                        .join("sample")
+                        .join("showcase.md"),
+                )]
+                .iter()
+                .map(|x| {
+                    let mut y = x.get_bufferlines(area);
+                    y.push(BufferLine::Line(Vec::new()));
+                    y
+                })
+                .flatten()
+                .collect()
+            });
+
+            frame.render_stateful_widget(FasterMarkdownWidget { t: v }, area, &mut offset);
+        })?;
+        loop {
+            if let Event::Key(key) = event::read()? {
+                if key.kind == event::KeyEventKind::Press {
+                    match &key.code {
+                        KeyCode::Char('q') => {
+                            break 'outer;
+                        }
+                        KeyCode::Char('j') => {
+                            offset.y = offset.y.saturating_add(1);
+                            break;
+                        }
+                        KeyCode::Char('k') => {
+                            offset.y = offset.y.saturating_sub(1);
+                            break;
+                        }
+                        KeyCode::Home => {
+                            offset.y = 0;
+                            break;
+                        }
+                        KeyCode::End => {
+                            offset.y = u16::MAX;
+                            break;
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+    }
+    disable_raw_mode()?;
+    stdout().execute(LeaveAlternateScreen)?;
+    Ok(())
+}

--- a/pulldown-cmark-mdcat/examples/slow.rs
+++ b/pulldown-cmark-mdcat/examples/slow.rs
@@ -1,0 +1,75 @@
+use crossterm::{
+    event::{self, Event, KeyCode},
+    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+    ExecutableCommand,
+};
+use pulldown_cmark_mdcat::markdown_widget::{MarkdownWidget, Offset, PathOrStr};
+use ratatui::prelude::*;
+use std::{
+    io::{self, stdout},
+    path::PathBuf,
+};
+
+fn main() -> io::Result<()> {
+    enable_raw_mode()?;
+    stdout().execute(EnterAlternateScreen)?;
+    let mut terminal = Terminal::new(CrosstermBackend::new(stdout()))?;
+
+    let mut offset = Offset { x: 0, y: 0 };
+
+    'outer: loop {
+        terminal.draw(|f| ui(f, &mut offset))?;
+        loop {
+            if let Event::Key(key) = event::read()? {
+                if key.kind == event::KeyEventKind::Press {
+                    match &key.code {
+                        KeyCode::Char('q') => {
+                            break 'outer;
+                        }
+                        KeyCode::Char('j') => {
+                            offset.y = offset.y.saturating_add(1);
+                            break;
+                        }
+                        KeyCode::Char('k') => {
+                            offset.y = offset.y.saturating_sub(1);
+                            break;
+                        }
+                        KeyCode::Home => {
+                            offset.y = 0;
+                            break;
+                        }
+                        KeyCode::End => {
+                            offset.y = u16::MAX;
+                            break;
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+    }
+    disable_raw_mode()?;
+    stdout().execute(LeaveAlternateScreen)?;
+    Ok(())
+}
+
+fn ui(frame: &mut Frame, offset: &mut Offset) {
+    let layout = Layout::new(
+        Direction::Horizontal,
+        [Constraint::Percentage(50), Constraint::Percentage(50)],
+    )
+    .split(frame.size());
+    frame.render_stateful_widget(
+        MarkdownWidget {
+            path_or_str: &vec![PathOrStr::from_md_path(
+                PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap())
+                    .parent()
+                    .unwrap()
+                    .join("sample")
+                    .join("showcase.md"),
+            )],
+        },
+        layout[1],
+        offset,
+    );
+}

--- a/pulldown-cmark-mdcat/src/bufferline.rs
+++ b/pulldown-cmark-mdcat/src/bufferline.rs
@@ -1,0 +1,118 @@
+use std::{
+    io::{stdout, Write},
+    mem,
+};
+
+use crossterm::{
+    cursor::{MoveTo, RestorePosition, SavePosition},
+    queue,
+};
+use ratatui::layout::Rect;
+
+use crate::markdown_widget::Offset;
+
+#[derive(Debug, Clone)]
+pub enum BufferLine {
+    Line(Vec<u8>),
+    Image { data: Vec<u8>, height: u16 },
+}
+
+impl BufferLine {
+    pub fn height(&self) -> u16 {
+        match self {
+            BufferLine::Line(_) => 1,
+            BufferLine::Image { height, .. } => *height,
+        }
+    }
+
+    pub fn data(&self) -> &[u8] {
+        match self {
+            BufferLine::Line(v) => v,
+            BufferLine::Image { data, .. } => data,
+        }
+    }
+}
+
+pub fn render_buffer_lines(buffer_lines: &[BufferLine], area: Rect, offset: &mut Offset) {
+    if buffer_lines.is_empty() {
+        return;
+    }
+    let accumulative_end: Vec<u16> = {
+        let mut v = Vec::new();
+        let mut a = 0;
+        for x in buffer_lines {
+            a += x.height();
+            v.push(a)
+        }
+        v
+    };
+    let mut start = match accumulative_end.binary_search_by(|x| x.cmp(&offset.y)) {
+        Ok(a) => a + 1,
+        Err(0) => 0,
+        Err(a) => a + 1,
+    };
+    if start >= buffer_lines.len() {
+        start = buffer_lines.len() - 1;
+    }
+
+    offset.y = accumulative_end[start] - buffer_lines[start].height();
+
+    let mut stdout = stdout().lock();
+    queue!(&mut stdout, SavePosition).unwrap();
+
+    let mut used_lines: u16 = 0;
+
+    for i in start..buffer_lines.len() {
+        if used_lines + buffer_lines[i].height() > area.height {
+            break;
+        } else {
+            queue!(&mut stdout, MoveTo(area.x, area.y + used_lines)).unwrap();
+            stdout.write_all(buffer_lines[i].data()).unwrap();
+            used_lines += buffer_lines[i].height();
+        }
+    }
+
+    queue!(&mut stdout, RestorePosition).unwrap();
+    stdout.flush().unwrap();
+}
+
+pub struct BufferLines {
+    pub lines: Vec<BufferLine>,
+    pub current_buffer: Vec<u8>,
+}
+
+impl BufferLines {
+    pub fn new() -> Self {
+        Self {
+            lines: Vec::new(),
+            current_buffer: Vec::new(),
+        }
+    }
+
+    pub fn finish(mut self) -> Vec<BufferLine> {
+        if !self.current_buffer.is_empty() {
+            self.lines.push(BufferLine::Line(self.current_buffer));
+        }
+        self.lines
+    }
+
+    pub fn writeln_buffer(&mut self) {
+        let old = mem::replace(&mut self.current_buffer, Vec::new());
+        self.lines.push(BufferLine::Line(old));
+    }
+
+    pub fn write_image(&mut self, height: u16) {
+        let data = mem::replace(&mut self.current_buffer, Vec::new());
+        self.lines.push(BufferLine::Image { data, height });
+    }
+}
+
+impl Write for BufferLines {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.current_buffer.write(buf)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.current_buffer.flush()
+    }
+}

--- a/pulldown-cmark-mdcat/src/markdown_widget.rs
+++ b/pulldown-cmark-mdcat/src/markdown_widget.rs
@@ -1,0 +1,205 @@
+// Copyright 2018-2020 Sebastian Wiesner <sebastian@swsnr.de>
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+use crate::{
+    bufferline::{render_buffer_lines, BufferLine, BufferLines},
+    push_tty,
+    reflow::{LineComposer, WordWrapper, WrappedLine},
+    resources::FileResourceHandler,
+    Environment, Settings, TerminalProgram, TerminalSize, Theme,
+};
+use pulldown_cmark::{Options, Parser};
+use ratatui::{prelude::*, widgets::StatefulWidget};
+use ratatui::{text::StyledGrapheme, widgets::Widget};
+use std::io::Write;
+use std::{fs, path::PathBuf};
+use syntect::parsing::SyntaxSet;
+use unicode_width::UnicodeWidthStr;
+
+///
+pub enum PathOrStr {
+    ///
+    MdPath(PathBuf, String),
+
+    ///
+    MdStr(String),
+
+    /// render String as normal text (just like Paragraph)
+    NormalStr(String),
+}
+
+impl PathOrStr {
+    ///
+    pub fn from_md_path(p: PathBuf) -> Self {
+        let input = fs::read_to_string(&p).unwrap();
+        Self::MdPath(p, input)
+    }
+
+    ///
+    pub fn get_str(&self) -> &str {
+        match self {
+            PathOrStr::MdPath(_, input) => input,
+            PathOrStr::MdStr(input) => input,
+            PathOrStr::NormalStr(input) => input,
+        }
+    }
+
+    fn get_parser<'input, 'callback>(&'input self) -> Parser<'input, 'callback> {
+        Parser::new_ext(
+            self.get_str(),
+            Options::ENABLE_TASKLISTS | Options::ENABLE_STRIKETHROUGH,
+        )
+    }
+
+    fn get_environment(&self) -> Environment {
+        match self {
+            PathOrStr::MdPath(p, _) => {
+                Environment::for_local_directory(&p.parent().unwrap()).unwrap()
+            }
+            // give a fake path
+            PathOrStr::MdStr(_) => Environment::for_local_directory(&PathBuf::from("/")).unwrap(),
+            PathOrStr::NormalStr(_) => unreachable!(),
+        }
+    }
+
+    pub fn get_bufferlines(&self, area: Rect) -> Vec<BufferLine> {
+        match self {
+            PathOrStr::MdPath(_, _) | PathOrStr::MdStr(_) => {
+                let terminal_capabilities = TerminalProgram::detect().capabilities();
+                let settings = Settings {
+                    terminal_capabilities,
+                    terminal_size: TerminalSize::detect()
+                        .unwrap_or_default()
+                        .with_max_columns(area.width),
+                    syntax_set: &SyntaxSet::load_defaults_newlines(),
+                    theme: Theme::default(),
+                };
+                let mut writer = BufferLines::new();
+                push_tty(
+                    &settings,
+                    &self.get_environment(),
+                    &FileResourceHandler::new(104_857_600),
+                    &mut writer,
+                    self.get_parser(),
+                )
+                .unwrap();
+
+                writer.finish()
+            }
+            PathOrStr::NormalStr(text) => {
+                let t = Text::raw(text);
+                let styled = t.lines.iter().map(|line| {
+                    let graphemes = line
+                        .spans
+                        .iter()
+                        .flat_map(|span| span.styled_graphemes(Style::default()));
+                    let alignment = line.alignment.unwrap_or(Alignment::Left);
+                    (graphemes, alignment)
+                });
+                let line_composer = WordWrapper::new(styled, area.width, true);
+                render_text(line_composer, area)
+            }
+        }
+    }
+}
+
+fn render_text<'a, C: LineComposer<'a>>(mut composer: C, _area: Rect) -> Vec<BufferLine> {
+    let mut writer = BufferLines::new();
+
+    while let Some(WrappedLine {
+        line: current_line,
+        width: _current_line_width,
+        alignment: _current_line_alignment,
+    }) = composer.next_line()
+    {
+        for StyledGrapheme {
+            symbol,
+            style: _style,
+        } in current_line
+        {
+            let width = symbol.width();
+            if width == 0 {
+                continue;
+            }
+            // If the symbol is empty, the last char which rendered last time will
+            // leave on the line. It's a quick fix.
+            let symbol = if symbol.is_empty() { " " } else { symbol };
+            write!(writer, "{symbol}").unwrap();
+        }
+        writer.writeln_buffer();
+    }
+    writer.finish()
+}
+
+/// similar to paragraph
+/// Robust but slow, especially when scroll frequently
+/// see example/slow.rs
+pub struct MarkdownWidget<'a> {
+    /// path of markdown file
+    pub path_or_str: &'a Vec<PathOrStr>,
+}
+
+impl Widget for MarkdownWidget<'_> {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        StatefulWidget::render(self, area, buf, &mut Offset { x: 0, y: 0 })
+    }
+}
+
+impl StatefulWidget for MarkdownWidget<'_> {
+    type State = Offset;
+
+    fn render(self, area: Rect, _buf: &mut Buffer, state: &mut Self::State) {
+        yazi_adaptor::init();
+        let terminal_capabilities = TerminalProgram::detect().capabilities();
+        terminal_capabilities
+            .image
+            .unwrap()
+            .image_erase(area)
+            .unwrap();
+
+        let buffer_lines: Vec<BufferLine> = self
+            .path_or_str
+            .iter()
+            .map(|x| {
+                let mut y = x.get_bufferlines(area);
+                y.push(BufferLine::Line(Vec::new()));
+                y
+            })
+            .flatten()
+            .collect();
+        render_buffer_lines(&buffer_lines, area, state);
+    }
+}
+
+/// Fast, but tricky to use
+/// see example/faster.rs
+pub struct FasterMarkdownWidget<T: AsRef<[BufferLine]>> {
+    pub t: T,
+}
+
+impl<T: AsRef<[BufferLine]>> StatefulWidget for FasterMarkdownWidget<T> {
+    type State = Offset;
+
+    fn render(self, area: Rect, _buf: &mut Buffer, state: &mut Self::State) {
+        yazi_adaptor::init();
+        TerminalProgram::detect()
+            .capabilities()
+            .image
+            .unwrap()
+            .image_erase(area)
+            .unwrap();
+
+        render_buffer_lines(&self.t.as_ref(), area, state);
+    }
+}
+
+///
+pub struct Offset {
+    /// uselesss now
+    pub x: u16,
+    ///
+    pub y: u16,
+}

--- a/pulldown-cmark-mdcat/src/reflow.rs
+++ b/pulldown-cmark-mdcat/src/reflow.rs
@@ -1,0 +1,709 @@
+use std::{collections::VecDeque, vec::IntoIter};
+
+use ratatui::{layout::Alignment, text::StyledGrapheme};
+use unicode_segmentation::UnicodeSegmentation;
+use unicode_width::UnicodeWidthStr;
+
+const NBSP: &str = "\u{00a0}";
+
+/// A state machine to pack styled symbols into lines.
+/// Cannot implement it as Iterator since it yields slices of the internal buffer (need streaming
+/// iterators for that).
+pub trait LineComposer<'a> {
+    fn next_line<'lend>(&'lend mut self) -> Option<WrappedLine<'lend, 'a>>;
+}
+
+pub struct WrappedLine<'lend, 'text> {
+    /// One line reflowed to the correct width
+    pub line: &'lend [StyledGrapheme<'text>],
+    /// The width of the line
+    pub width: u16,
+    /// Whether the line was aligned left or right
+    pub alignment: Alignment,
+}
+
+/// A state machine that wraps lines on word boundaries.
+#[derive(Debug, Default, Clone)]
+pub struct WordWrapper<'a, O, I>
+where
+    // Outer iterator providing the individual lines
+    O: Iterator<Item = (I, Alignment)>,
+    // Inner iterator providing the styled symbols of a line Each line consists of an alignment and
+    // a series of symbols
+    I: Iterator<Item = StyledGrapheme<'a>>,
+{
+    /// The given, unprocessed lines
+    input_lines: O,
+    max_line_width: u16,
+    wrapped_lines: Option<IntoIter<Vec<StyledGrapheme<'a>>>>,
+    current_alignment: Alignment,
+    current_line: Vec<StyledGrapheme<'a>>,
+    /// Removes the leading whitespace from lines
+    trim: bool,
+}
+
+impl<'a, O, I> WordWrapper<'a, O, I>
+where
+    O: Iterator<Item = (I, Alignment)>,
+    I: Iterator<Item = StyledGrapheme<'a>>,
+{
+    pub fn new(lines: O, max_line_width: u16, trim: bool) -> WordWrapper<'a, O, I> {
+        WordWrapper {
+            input_lines: lines,
+            max_line_width,
+            wrapped_lines: None,
+            current_alignment: Alignment::Left,
+            current_line: vec![],
+            trim,
+        }
+    }
+}
+
+impl<'a, O, I> LineComposer<'a> for WordWrapper<'a, O, I>
+where
+    O: Iterator<Item = (I, Alignment)>,
+    I: Iterator<Item = StyledGrapheme<'a>>,
+{
+    fn next_line<'lend>(&'lend mut self) -> Option<WrappedLine<'lend, 'a>> {
+        if self.max_line_width == 0 {
+            return None;
+        }
+
+        let mut current_line: Option<Vec<StyledGrapheme<'a>>> = None;
+        let mut line_width: u16 = 0;
+
+        // Try to repeatedly retrieve next line
+        while current_line.is_none() {
+            // Retrieve next preprocessed wrapped line
+            if let Some(line_iterator) = &mut self.wrapped_lines {
+                if let Some(line) = line_iterator.next() {
+                    line_width = line
+                        .iter()
+                        .map(|grapheme| grapheme.symbol.width())
+                        .sum::<usize>() as u16;
+                    current_line = Some(line);
+                }
+            }
+
+            // When no more preprocessed wrapped lines
+            if current_line.is_none() {
+                // Try to calculate next wrapped lines based on current whole line
+                if let Some((line_symbols, line_alignment)) = &mut self.input_lines.next() {
+                    // Save the whole line's alignment
+                    self.current_alignment = *line_alignment;
+                    let mut wrapped_lines = vec![]; // Saves the wrapped lines
+                                                    // Saves the unfinished wrapped line
+                    let (mut current_line, mut current_line_width) = (vec![], 0);
+                    // Saves the partially processed word
+                    let (mut unfinished_word, mut word_width) = (vec![], 0);
+                    // Saves the whitespaces of the partially unfinished word
+                    let (mut unfinished_whitespaces, mut whitespace_width) =
+                        (VecDeque::<StyledGrapheme>::new(), 0);
+
+                    let mut has_seen_non_whitespace = false;
+                    for StyledGrapheme { symbol, style } in line_symbols {
+                        let symbol_whitespace =
+                            symbol.chars().all(&char::is_whitespace) && symbol != NBSP;
+                        let symbol_width = symbol.width() as u16;
+                        // Ignore characters wider than the total max width
+                        if symbol_width > self.max_line_width {
+                            continue;
+                        }
+
+                        // Append finished word to current line
+                        if has_seen_non_whitespace && symbol_whitespace
+                            // Append if trimmed (whitespaces removed) word would overflow
+                            || word_width + symbol_width > self.max_line_width && current_line.is_empty() && self.trim
+                            // Append if removed whitespace would overflow -> reset whitespace counting to prevent overflow
+                            || whitespace_width + symbol_width > self.max_line_width && current_line.is_empty() && self.trim
+                            // Append if complete word would overflow
+                            || word_width + whitespace_width + symbol_width > self.max_line_width && current_line.is_empty() && !self.trim
+                        {
+                            if !current_line.is_empty() || !self.trim {
+                                // Also append whitespaces if not trimming or current line is not
+                                // empty
+                                current_line.extend(
+                                    std::mem::take(&mut unfinished_whitespaces).into_iter(),
+                                );
+                                current_line_width += whitespace_width;
+                            }
+                            // Append trimmed word
+                            current_line.append(&mut unfinished_word);
+                            current_line_width += word_width;
+
+                            // Clear whitespace buffer
+                            unfinished_whitespaces.clear();
+                            whitespace_width = 0;
+                            word_width = 0;
+                        }
+
+                        // Append the unfinished wrapped line to wrapped lines if it is as wide as
+                        // max line width
+                        if current_line_width >= self.max_line_width
+                            // or if it would be too long with the current partially processed word added
+                            || current_line_width + whitespace_width + word_width >= self.max_line_width && symbol_width > 0
+                        {
+                            let mut remaining_width =
+                                (self.max_line_width as i32 - current_line_width as i32).max(0)
+                                    as u16;
+                            wrapped_lines.push(std::mem::take(&mut current_line));
+                            current_line_width = 0;
+
+                            // Remove all whitespaces till end of just appended wrapped line + next
+                            // whitespace
+                            let mut first_whitespace = unfinished_whitespaces.pop_front();
+                            while let Some(grapheme) = first_whitespace.as_ref() {
+                                let symbol_width = grapheme.symbol.width() as u16;
+                                whitespace_width -= symbol_width;
+
+                                if symbol_width > remaining_width {
+                                    break;
+                                }
+                                remaining_width -= symbol_width;
+                                first_whitespace = unfinished_whitespaces.pop_front();
+                            }
+                            // In case all whitespaces have been exhausted
+                            if symbol_whitespace && first_whitespace.is_none() {
+                                // Prevent first whitespace to count towards next word
+                                continue;
+                            }
+                        }
+
+                        // Append symbol to unfinished, partially processed word
+                        if symbol_whitespace {
+                            whitespace_width += symbol_width;
+                            unfinished_whitespaces.push_back(StyledGrapheme { symbol, style });
+                        } else {
+                            word_width += symbol_width;
+                            unfinished_word.push(StyledGrapheme { symbol, style });
+                        }
+
+                        has_seen_non_whitespace = !symbol_whitespace;
+                    }
+
+                    // Append remaining text parts
+                    if !unfinished_word.is_empty() || !unfinished_whitespaces.is_empty() {
+                        if current_line.is_empty() && unfinished_word.is_empty() {
+                            wrapped_lines.push(vec![]);
+                        } else if !self.trim || !current_line.is_empty() {
+                            current_line.extend(unfinished_whitespaces.into_iter());
+                        }
+                        current_line.append(&mut unfinished_word);
+                    }
+                    if !current_line.is_empty() {
+                        wrapped_lines.push(current_line);
+                    }
+                    if wrapped_lines.is_empty() {
+                        // Append empty line if there was nothing to wrap in the first place
+                        wrapped_lines.push(vec![]);
+                    }
+
+                    self.wrapped_lines = Some(wrapped_lines.into_iter());
+                } else {
+                    // No more whole lines available -> stop repeatedly retrieving next wrapped line
+                    break;
+                }
+            }
+        }
+
+        if let Some(line) = current_line {
+            self.current_line = line;
+            Some(WrappedLine {
+                line: &self.current_line[..],
+                width: line_width,
+                alignment: self.current_alignment,
+            })
+        } else {
+            None
+        }
+    }
+}
+
+/// A state machine that truncates overhanging lines.
+#[derive(Debug, Default, Clone)]
+pub struct LineTruncator<'a, O, I>
+where
+    // Outer iterator providing the individual lines
+    O: Iterator<Item = (I, Alignment)>,
+    // Inner iterator providing the styled symbols of a line Each line consists of an alignment and
+    // a series of symbols
+    I: Iterator<Item = StyledGrapheme<'a>>,
+{
+    /// The given, unprocessed lines
+    input_lines: O,
+    max_line_width: u16,
+    current_line: Vec<StyledGrapheme<'a>>,
+    /// Record the offset to skip render
+    horizontal_offset: u16,
+}
+
+impl<'a, O, I> LineTruncator<'a, O, I>
+where
+    O: Iterator<Item = (I, Alignment)>,
+    I: Iterator<Item = StyledGrapheme<'a>>,
+{
+    pub fn new(lines: O, max_line_width: u16) -> LineTruncator<'a, O, I> {
+        LineTruncator {
+            input_lines: lines,
+            max_line_width,
+            horizontal_offset: 0,
+            current_line: vec![],
+        }
+    }
+
+    pub fn set_horizontal_offset(&mut self, horizontal_offset: u16) {
+        self.horizontal_offset = horizontal_offset;
+    }
+}
+
+impl<'a, O, I> LineComposer<'a> for LineTruncator<'a, O, I>
+where
+    O: Iterator<Item = (I, Alignment)>,
+    I: Iterator<Item = StyledGrapheme<'a>>,
+{
+    fn next_line<'lend>(&'lend mut self) -> Option<WrappedLine<'lend, 'a>> {
+        if self.max_line_width == 0 {
+            return None;
+        }
+
+        self.current_line.truncate(0);
+        let mut current_line_width = 0;
+
+        let mut lines_exhausted = true;
+        let mut horizontal_offset = self.horizontal_offset as usize;
+        let mut current_alignment = Alignment::Left;
+        if let Some((current_line, alignment)) = &mut self.input_lines.next() {
+            lines_exhausted = false;
+            current_alignment = *alignment;
+
+            for StyledGrapheme { symbol, style } in current_line {
+                // Ignore characters wider that the total max width.
+                if symbol.width() as u16 > self.max_line_width {
+                    continue;
+                }
+
+                if current_line_width + symbol.width() as u16 > self.max_line_width {
+                    // Truncate line
+                    break;
+                }
+
+                let symbol = if horizontal_offset == 0 || Alignment::Left != *alignment {
+                    symbol
+                } else {
+                    let w = symbol.width();
+                    if w > horizontal_offset {
+                        let t = trim_offset(symbol, horizontal_offset);
+                        horizontal_offset = 0;
+                        t
+                    } else {
+                        horizontal_offset -= w;
+                        ""
+                    }
+                };
+                current_line_width += symbol.width() as u16;
+                self.current_line.push(StyledGrapheme { symbol, style });
+            }
+        }
+
+        if lines_exhausted {
+            None
+        } else {
+            Some(WrappedLine {
+                line: &self.current_line[..],
+                width: current_line_width,
+                alignment: current_alignment,
+            })
+        }
+    }
+}
+
+/// This function will return a str slice which start at specified offset.
+/// As src is a unicode str, start offset has to be calculated with each character.
+fn trim_offset(src: &str, mut offset: usize) -> &str {
+    let mut start = 0;
+    for c in UnicodeSegmentation::graphemes(src, true) {
+        let w = c.width();
+        if w <= offset {
+            offset -= w;
+            start += c.len();
+        } else {
+            break;
+        }
+    }
+    &src[start..]
+}
+
+#[cfg(test)]
+mod test {
+    use unicode_segmentation::UnicodeSegmentation;
+
+    use super::*;
+    use crate::{
+        style::Style,
+        text::{Line, Text},
+    };
+
+    enum Composer {
+        WordWrapper { trim: bool },
+        LineTruncator,
+    }
+
+    fn run_composer<'a>(
+        which: Composer,
+        text: impl Into<Text<'a>>,
+        text_area_width: u16,
+    ) -> (Vec<String>, Vec<u16>, Vec<Alignment>) {
+        let text = text.into();
+        let styled_lines = text.lines.iter().map(|line| {
+            (
+                line.spans
+                    .iter()
+                    .flat_map(|span| span.styled_graphemes(Style::default())),
+                line.alignment.unwrap_or(Alignment::Left),
+            )
+        });
+
+        let mut composer: Box<dyn LineComposer> = match which {
+            Composer::WordWrapper { trim } => {
+                Box::new(WordWrapper::new(styled_lines, text_area_width, trim))
+            }
+            Composer::LineTruncator => Box::new(LineTruncator::new(styled_lines, text_area_width)),
+        };
+        let mut lines = vec![];
+        let mut widths = vec![];
+        let mut alignments = vec![];
+        while let Some(WrappedLine {
+            line: styled,
+            width,
+            alignment,
+        }) = composer.next_line()
+        {
+            let line = styled
+                .iter()
+                .map(|StyledGrapheme { symbol, .. }| *symbol)
+                .collect::<String>();
+            assert!(width <= text_area_width);
+            lines.push(line);
+            widths.push(width);
+            alignments.push(alignment);
+        }
+        (lines, widths, alignments)
+    }
+
+    #[test]
+    fn line_composer_one_line() {
+        let width = 40;
+        for i in 1..width {
+            let text = "a".repeat(i);
+            let (word_wrapper, _, _) = run_composer(
+                Composer::WordWrapper { trim: true },
+                &text[..],
+                width as u16,
+            );
+            let (line_truncator, _, _) =
+                run_composer(Composer::LineTruncator, &text[..], width as u16);
+            let expected = vec![text];
+            assert_eq!(word_wrapper, expected);
+            assert_eq!(line_truncator, expected);
+        }
+    }
+
+    #[test]
+    fn line_composer_short_lines() {
+        let width = 20;
+        let text =
+            "abcdefg\nhijklmno\npabcdefg\nhijklmn\nopabcdefghijk\nlmnopabcd\n\n\nefghijklmno";
+        let (word_wrapper, _, _) = run_composer(Composer::WordWrapper { trim: true }, text, width);
+        let (line_truncator, _, _) = run_composer(Composer::LineTruncator, text, width);
+
+        let wrapped: Vec<&str> = text.split('\n').collect();
+        assert_eq!(word_wrapper, wrapped);
+        assert_eq!(line_truncator, wrapped);
+    }
+
+    #[test]
+    fn line_composer_long_word() {
+        let width = 20;
+        let text = "abcdefghijklmnopabcdefghijklmnopabcdefghijklmnopabcdefghijklmno";
+        let (word_wrapper, _, _) =
+            run_composer(Composer::WordWrapper { trim: true }, text, width as u16);
+        let (line_truncator, _, _) = run_composer(Composer::LineTruncator, text, width as u16);
+
+        let wrapped = vec![
+            &text[..width],
+            &text[width..width * 2],
+            &text[width * 2..width * 3],
+            &text[width * 3..],
+        ];
+        assert_eq!(
+            word_wrapper, wrapped,
+            "WordWrapper should detect the line cannot be broken on word boundary and \
+             break it at line width limit."
+        );
+        assert_eq!(line_truncator, vec![&text[..width]]);
+    }
+
+    #[test]
+    fn line_composer_long_sentence() {
+        let width = 20;
+        let text =
+            "abcd efghij klmnopabcd efgh ijklmnopabcdefg hijkl mnopab c d e f g h i j k l m n o";
+        let text_multi_space =
+            "abcd efghij    klmnopabcd efgh     ijklmnopabcdefg hijkl mnopab c d e f g h i j k l \
+             m n o";
+        let (word_wrapper_single_space, _, _) =
+            run_composer(Composer::WordWrapper { trim: true }, text, width as u16);
+        let (word_wrapper_multi_space, _, _) = run_composer(
+            Composer::WordWrapper { trim: true },
+            text_multi_space,
+            width as u16,
+        );
+        let (line_truncator, _, _) = run_composer(Composer::LineTruncator, text, width as u16);
+
+        let word_wrapped = vec![
+            "abcd efghij",
+            "klmnopabcd efgh",
+            "ijklmnopabcdefg",
+            "hijkl mnopab c d e f",
+            "g h i j k l m n o",
+        ];
+        assert_eq!(word_wrapper_single_space, word_wrapped);
+        assert_eq!(word_wrapper_multi_space, word_wrapped);
+
+        assert_eq!(line_truncator, vec![&text[..width]]);
+    }
+
+    #[test]
+    fn line_composer_zero_width() {
+        let width = 0;
+        let text = "abcd efghij klmnopabcd efgh ijklmnopabcdefg hijkl mnopab ";
+        let (word_wrapper, _, _) = run_composer(Composer::WordWrapper { trim: true }, text, width);
+        let (line_truncator, _, _) = run_composer(Composer::LineTruncator, text, width);
+
+        let expected: Vec<&str> = Vec::new();
+        assert_eq!(word_wrapper, expected);
+        assert_eq!(line_truncator, expected);
+    }
+
+    #[test]
+    fn line_composer_max_line_width_of_1() {
+        let width = 1;
+        let text = "abcd efghij klmnopabcd efgh ijklmnopabcdefg hijkl mnopab ";
+        let (word_wrapper, _, _) = run_composer(Composer::WordWrapper { trim: true }, text, width);
+        let (line_truncator, _, _) = run_composer(Composer::LineTruncator, text, width);
+
+        let expected: Vec<&str> = UnicodeSegmentation::graphemes(text, true)
+            .filter(|g| g.chars().any(|c| !c.is_whitespace()))
+            .collect();
+        assert_eq!(word_wrapper, expected);
+        assert_eq!(line_truncator, vec!["a"]);
+    }
+
+    #[test]
+    fn line_composer_max_line_width_of_1_double_width_characters() {
+        let width = 1;
+        let text =
+            "コンピュータ上で文字を扱う場合、典型的には文字\naaa\naによる通信を行う場合にその\
+                    両端点では、";
+        let (word_wrapper, _, _) = run_composer(Composer::WordWrapper { trim: true }, text, width);
+        let (line_truncator, _, _) = run_composer(Composer::LineTruncator, text, width);
+        assert_eq!(word_wrapper, vec!["", "a", "a", "a", "a"]);
+        assert_eq!(line_truncator, vec!["", "a", "a"]);
+    }
+
+    /// Tests `WordWrapper` with words some of which exceed line length and some not.
+    #[test]
+    fn line_composer_word_wrapper_mixed_length() {
+        let width = 20;
+        let text = "abcd efghij klmnopabcdefghijklmnopabcdefghijkl mnopab cdefghi j klmno";
+        let (word_wrapper, _, _) = run_composer(Composer::WordWrapper { trim: true }, text, width);
+        assert_eq!(
+            word_wrapper,
+            vec![
+                "abcd efghij",
+                "klmnopabcdefghijklmn",
+                "opabcdefghijkl",
+                "mnopab cdefghi j",
+                "klmno",
+            ]
+        );
+    }
+
+    #[test]
+    fn line_composer_double_width_chars() {
+        let width = 20;
+        let text = "コンピュータ上で文字を扱う場合、典型的には文字による通信を行う場合にその両端点\
+                    では、";
+        let (word_wrapper, word_wrapper_width, _) =
+            run_composer(Composer::WordWrapper { trim: true }, text, width);
+        let (line_truncator, _, _) = run_composer(Composer::LineTruncator, text, width);
+        assert_eq!(line_truncator, vec!["コンピュータ上で文字"]);
+        let wrapped = vec![
+            "コンピュータ上で文字",
+            "を扱う場合、典型的に",
+            "は文字による通信を行",
+            "う場合にその両端点で",
+            "は、",
+        ];
+        assert_eq!(word_wrapper, wrapped);
+        assert_eq!(word_wrapper_width, vec![width, width, width, width, 4]);
+    }
+
+    #[test]
+    fn line_composer_leading_whitespace_removal() {
+        let width = 20;
+        let text = "AAAAAAAAAAAAAAAAAAAA    AAA";
+        let (word_wrapper, _, _) = run_composer(Composer::WordWrapper { trim: true }, text, width);
+        let (line_truncator, _, _) = run_composer(Composer::LineTruncator, text, width);
+        assert_eq!(word_wrapper, vec!["AAAAAAAAAAAAAAAAAAAA", "AAA",]);
+        assert_eq!(line_truncator, vec!["AAAAAAAAAAAAAAAAAAAA"]);
+    }
+
+    /// Tests truncation of leading whitespace.
+    #[test]
+    fn line_composer_lots_of_spaces() {
+        let width = 20;
+        let text = "                                                                     ";
+        let (word_wrapper, _, _) = run_composer(Composer::WordWrapper { trim: true }, text, width);
+        let (line_truncator, _, _) = run_composer(Composer::LineTruncator, text, width);
+        assert_eq!(word_wrapper, vec![""]);
+        assert_eq!(line_truncator, vec!["                    "]);
+    }
+
+    /// Tests an input starting with a letter, followed by spaces - some of the behaviour is
+    /// incidental.
+    #[test]
+    fn line_composer_char_plus_lots_of_spaces() {
+        let width = 20;
+        let text = "a                                                                     ";
+        let (word_wrapper, _, _) = run_composer(Composer::WordWrapper { trim: true }, text, width);
+        let (line_truncator, _, _) = run_composer(Composer::LineTruncator, text, width);
+        // What's happening below is: the first line gets consumed, trailing spaces discarded,
+        // after 20 of which a word break occurs (probably shouldn't). The second line break
+        // discards all whitespace. The result should probably be vec!["a"] but it doesn't matter
+        // that much.
+        assert_eq!(word_wrapper, vec!["a", ""]);
+        assert_eq!(line_truncator, vec!["a                   "]);
+    }
+
+    #[test]
+    fn line_composer_word_wrapper_double_width_chars_mixed_with_spaces() {
+        let width = 20;
+        // Japanese seems not to use spaces but we should break on spaces anyway... We're using it
+        // to test double-width chars.
+        // You are more than welcome to add word boundary detection based of alterations of
+        // hiragana and katakana...
+        // This happens to also be a test case for mixed width because regular spaces are single
+        // width.
+        let text = "コンピュ ータ上で文字を扱う場合、 典型的には文 字による 通信を行 う場合にその両端点では、";
+        let (word_wrapper, word_wrapper_width, _) =
+            run_composer(Composer::WordWrapper { trim: true }, text, width);
+        assert_eq!(
+            word_wrapper,
+            vec![
+                "コンピュ",
+                "ータ上で文字を扱う場",
+                "合、 典型的には文",
+                "字による 通信を行",
+                "う場合にその両端点で",
+                "は、",
+            ]
+        );
+        // Odd-sized lines have a space in them.
+        assert_eq!(word_wrapper_width, vec![8, 20, 17, 17, 20, 4]);
+    }
+
+    /// Ensure words separated by nbsp are wrapped as if they were a single one.
+    #[test]
+    fn line_composer_word_wrapper_nbsp() {
+        let width = 20;
+        let text = "AAAAAAAAAAAAAAA AAAA\u{00a0}AAA";
+        let (word_wrapper, word_wrapper_widths, _) =
+            run_composer(Composer::WordWrapper { trim: true }, text, width);
+        assert_eq!(word_wrapper, vec!["AAAAAAAAAAAAAAA", "AAAA\u{00a0}AAA",]);
+        assert_eq!(word_wrapper_widths, vec![15, 8]);
+
+        // Ensure that if the character was a regular space, it would be wrapped differently.
+        let text_space = text.replace('\u{00a0}', " ");
+        let (word_wrapper_space, word_wrapper_widths, _) =
+            run_composer(Composer::WordWrapper { trim: true }, text_space, width);
+        assert_eq!(word_wrapper_space, vec!["AAAAAAAAAAAAAAA AAAA", "AAA",]);
+        assert_eq!(word_wrapper_widths, vec![20, 3])
+    }
+
+    #[test]
+    fn line_composer_word_wrapper_preserve_indentation() {
+        let width = 20;
+        let text = "AAAAAAAAAAAAAAAAAAAA    AAA";
+        let (word_wrapper, _, _) = run_composer(Composer::WordWrapper { trim: false }, text, width);
+        assert_eq!(word_wrapper, vec!["AAAAAAAAAAAAAAAAAAAA", "   AAA",]);
+    }
+
+    #[test]
+    fn line_composer_word_wrapper_preserve_indentation_with_wrap() {
+        let width = 10;
+        let text = "AAA AAA AAAAA AA AAAAAA\n B\n  C\n   D";
+        let (word_wrapper, _, _) = run_composer(Composer::WordWrapper { trim: false }, text, width);
+        assert_eq!(
+            word_wrapper,
+            vec!["AAA AAA", "AAAAA AA", "AAAAAA", " B", "  C", "   D"]
+        );
+    }
+
+    #[test]
+    fn line_composer_word_wrapper_preserve_indentation_lots_of_whitespace() {
+        let width = 10;
+        let text = "               4 Indent\n                 must wrap!";
+        let (word_wrapper, _, _) = run_composer(Composer::WordWrapper { trim: false }, text, width);
+        assert_eq!(
+            word_wrapper,
+            vec![
+                "          ",
+                "    4",
+                "Indent",
+                "          ",
+                "      must",
+                "wrap!"
+            ]
+        );
+    }
+
+    #[test]
+    fn line_composer_zero_width_at_end() {
+        let width = 3;
+        let line = "foo\0";
+        let (word_wrapper, _, _) = run_composer(Composer::WordWrapper { trim: true }, line, width);
+        let (line_truncator, _, _) = run_composer(Composer::LineTruncator, line, width);
+        assert_eq!(word_wrapper, vec!["foo\0"]);
+        assert_eq!(line_truncator, vec!["foo\0"]);
+    }
+
+    #[test]
+    fn line_composer_preserves_line_alignment() {
+        let width = 20;
+        let lines = vec![
+            Line::from("Something that is left aligned.").alignment(Alignment::Left),
+            Line::from("This is right aligned and half short.").alignment(Alignment::Right),
+            Line::from("This should sit in the center.").alignment(Alignment::Center),
+        ];
+        let (_, _, wrapped_alignments) =
+            run_composer(Composer::WordWrapper { trim: true }, lines.clone(), width);
+        let (_, _, truncated_alignments) = run_composer(Composer::LineTruncator, lines, width);
+        assert_eq!(
+            wrapped_alignments,
+            vec![
+                Alignment::Left,
+                Alignment::Left,
+                Alignment::Right,
+                Alignment::Right,
+                Alignment::Right,
+                Alignment::Center,
+                Alignment::Center
+            ]
+        );
+        assert_eq!(
+            truncated_alignments,
+            vec![Alignment::Left, Alignment::Right, Alignment::Center]
+        );
+    }
+}

--- a/pulldown-cmark-mdcat/src/resources/image.rs
+++ b/pulldown-cmark-mdcat/src/resources/image.rs
@@ -6,11 +6,9 @@
 
 //! Inline image handling
 
-use std::io::Write;
-
 use url::Url;
 
-use crate::{ResourceUrlHandler, TerminalSize};
+use crate::{bufferline::BufferLines, ResourceUrlHandler, TerminalSize};
 
 /// An implementation of an inline image protocol.
 pub trait InlineImageProtocol {
@@ -28,7 +26,7 @@ pub trait InlineImageProtocol {
     /// support the given image format.
     fn write_inline_image(
         &self,
-        writer: &mut dyn Write,
+        writer: &mut BufferLines,
         resource_handler: &dyn ResourceUrlHandler,
         url: &Url,
         terminal_size: TerminalSize,

--- a/pulldown-cmark-mdcat/src/terminal/capabilities.rs
+++ b/pulldown-cmark-mdcat/src/terminal/capabilities.rs
@@ -6,6 +6,9 @@
 
 //! Capabilities of terminal emulators.
 
+use anyhow::Result;
+use ratatui::layout::Rect;
+
 use crate::resources::InlineImageProtocol;
 
 pub mod iterm2;
@@ -43,6 +46,15 @@ impl ImageCapability {
             ImageCapability::Terminology(t) => t,
             ImageCapability::ITerm2(t) => t,
             ImageCapability::Kitty(t) => t,
+        }
+    }
+
+    /// copy from yazi
+    pub fn image_erase(self, rect: Rect) -> Result<()> {
+        match self {
+            Self::Kitty(_) => yazi_adaptor::kitty::Kitty::image_erase(rect),
+            Self::ITerm2(_) => yazi_adaptor::iterm2::Iterm2::image_erase(rect),
+            _ => todo!(),
         }
     }
 }

--- a/pulldown-cmark-mdcat/src/terminal/capabilities/terminology.rs
+++ b/pulldown-cmark-mdcat/src/terminal/capabilities/terminology.rs
@@ -16,7 +16,10 @@
 //!
 //! This module implements the terminology image protocol.
 
-use crate::{resources::InlineImageProtocol, terminal::TerminalSize, ResourceUrlHandler};
+use crate::{
+    bufferline::BufferLines, resources::InlineImageProtocol, terminal::TerminalSize,
+    ResourceUrlHandler,
+};
 use std::io::{Result, Write};
 use tracing::{event, Level};
 use url::Url;
@@ -90,7 +93,7 @@ fn get_image_dimensions(_url: &Url) -> Option<(u32, u32)> {
 impl InlineImageProtocol for Terminology {
     fn write_inline_image(
         &self,
-        writer: &mut dyn Write,
+        writer: &mut BufferLines,
         _resource_handler: &dyn ResourceUrlHandler,
         url: &Url,
         terminal_size: TerminalSize,
@@ -110,6 +113,13 @@ impl InlineImageProtocol for Terminology {
             command.push_str("\x1b}ie\x00\n");
         }
         writer.write_all(command.as_bytes())?;
+        /*
+        TODO: how to do ?
+        buffer_lines.push(BufferLine {
+            occupied_lines: dynamic_image.height().try_into().unwrap(),
+            offset: writer.len(),
+        });
+         */
         Ok(())
     }
 }


### PR DESCRIPTION
Make mdcat work in ratatui

Hacks every `writeln`, collect every line in a vector, and then write to screen one by one

```
cargo run --example fast
cargo run --example slow
```