### PR TITLE
Update tracing instructions in manpage

### DIFF
--- a/mdcat.1.adoc
+++ b/mdcat.1.adoc
@@ -215,7 +215,7 @@ Matches partial hostnames (e.g. `example.org` also disables proxy for `www.examp
 MDCAT_LOG::
     Directives to configure output of tracing information.
 +
-See <https://docs.rs/tracing-subscriber/latest/tracing_subscriber/struct.EnvFilter.html#directives> for syntax details; use `MDCAT_LOG=trace` for complete debugging information, and `MDCAT_LOG=mdcat::render=trace` to trace rendering only.
+See <https://docs.rs/tracing-subscriber/latest/tracing_subscriber/struct.EnvFilter.html#directives> for syntax details; use `MDCAT_LOG=trace` for complete debugging information, and `MDCAT_LOG=pulldown_cmark_mdcat::render=trace` to trace rendering only.
 
 == Conforming to
 


### PR DESCRIPTION
Rendering of mdcat was split off into the pulldown_cmark_mdcat crate (see 8b119cb193cb8e70d8d372c33f9c2d80de7ad4ba), so in this PR we update the instructions for tracing rendering in manpage accordingly.

Thanks!