### PR TITLE
Ignore inline HTML in table cells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ Use `cargo release` to create a new release.
 - Drop macOS release builds.  Use homebrew to obtain macOS binaries of `mdcat`.
 - Remove simplified panic message; `mdcat` now uses the default panic handler.
 
+### Fixed
+- Do not crash on inline HTML elements in a table cell (see [GH-310]).
+
+[GH-310]: https://github.com/swsnr/mdcat/pull/310
+
 ## [2.7.0] – 2024-11-24
 
 ### Changed

--- a/pulldown-cmark-mdcat/src/render.rs
+++ b/pulldown-cmark-mdcat/src/render.rs
@@ -933,7 +933,8 @@ pub fn write_event<'a, W: Write>(
         | (Stacked(stack, TableBlock), End(TagEnd::Strong))
         | (Stacked(stack, TableBlock), End(TagEnd::Strikethrough))
         | (Stacked(stack, TableBlock), End(TagEnd::Link))
-        | (Stacked(stack, TableBlock), End(TagEnd::Image)) => {
+        | (Stacked(stack, TableBlock), End(TagEnd::Image))
+        | (Stacked(stack, TableBlock), InlineHtml(_)) => {
             Stacked(stack, TableBlock).and_data(data).ok()
         }
 


### PR DESCRIPTION
Instead of panicking, currently `mdcat` ignores inline elements in a table cell. `InlineHtml` was left out unanticipatedly, so this commit adds it.

Re: #306 (@suvayu Could you check if this fixes the crash you encountered?)